### PR TITLE
Update docker configuration with latest of 2020

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 MAINTAINER CodeX Team <github.com/codex-team>
 
-ENV NGINX_VERSION 1.12.2
+ENV NGINX_VERSION 1.13.1
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.1-fpm
+FROM php:7.1-fpm-stretch
 
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
-        libpng12-dev \
+        libpng-dev \
         libssl-dev \
     && pecl install mongodb \
     && echo "extension=mongodb.so" > /usr/local/etc/php/conf.d/ext-mongodb.ini \


### PR DESCRIPTION
There is a bad practice to set **latest** in Docker configuration.
This request aims to fix image major version and resolve changed dependency of libpng-dev